### PR TITLE
Ajustando a URL do livro Eloquent Javascript

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Relação de livros em PT-BR
 
 ### [Javacript](https://github.com/cerebrobr/livros/tree/master/JavaScript/)
-- [Eloquent JavaScript - 2ª Edição](http://eloquentjavascript.com.br/)
+- [Eloquent JavaScript - 2ª Edição](http://braziljs.github.io/eloquente-javascript/)
 
 #### [jQuery](https://github.com/cerebrobr/livros/tree/master/JavaScript/Jquery)
 - [Fundamentos de jQuery](https://github.com/cerebrobr/livros/blob/master/JavaScript/Jquery/jquery-fundamentals-book-pt-BR.pdf)


### PR DESCRIPTION
Opa, tudo bom?!

Acabei descobrindo o cérebro e cheguei a dar um overview básico e vi que o link para o JavaScript Eloquente está quebrado, mas já foi consertado!